### PR TITLE
Fixed compilation with GHC 7.6.3

### DIFF
--- a/Control/Monad/ST/Trans.hs
+++ b/Control/Monad/ST/Trans.hs
@@ -52,7 +52,13 @@ import GHC.Arr (Ix(..), safeRangeSize, safeIndex,
                 Array(..), arrEleBottom)
 import qualified GHC.Arr as STArray
 import GHC.ST hiding (runST, liftST)
-import Control.Monad.ST hiding (runST)
+
+import Control.Monad.ST hiding
+  ( runST
+#if !MIN_VERSION_base(4,7,0)
+  , unsafeSTToIO
+#endif
+  )
 
 import Data.STRef (STRef)
 import qualified Data.STRef as STRef


### PR DESCRIPTION
Using GHC 7.6.3 I got the error:

```
$ cabal install
Control/Monad/ST/Trans.hs:45:7:
    Ambiguous occurrence `unsafeSTToIO'
    It could refer to either `Control.Monad.ST.Trans.unsafeSTToIO',
                             defined at Control/Monad/ST/Trans.hs:169:1
                          or `Control.Monad.ST.unsafeSTToIO',
                             imported from `Control.Monad.ST' at Control/Monad/ST/Trans.hs:55:1-38
```
This PR fix this issue which is blocking https://github.com/agda/agda/issues/2443.

