### PR TITLE
Delete test suite "foo"

### DIFF
--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -44,13 +44,6 @@ library
 
   ghc-options: -Wall -fwarn-tabs
 
-test-suite foo
-  type: detailed-0.9
-  hs-source-dirs: test
-  test-module: Test
-  build-depends: STMonadTrans, base, mtl, array, Cabal
-  extensions: CPP
-
 test-suite test
   default-language: Haskell2010
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
Fixes #15 

This should allow us not to add this package to `expect-test-failure` section on Stackage.