### PR TITLE
Supported GHC 8.8.1

### DIFF
--- a/Control/Monad/ST/Trans/Internal.hs
+++ b/Control/Monad/ST/Trans/Internal.hs
@@ -26,6 +26,7 @@ module Control.Monad.ST.Trans.Internal where
 import GHC.Base
 import GHC.ST hiding (liftST)
 
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Fix
 import Control.Monad.Trans
 import Control.Monad.Error.Class
@@ -71,6 +72,8 @@ instance Monad m => Monad (STT s m) where
        case ret of
          STTRet new_st a -> 
              unSTT (k a) new_st
+
+instance MF.MonadFail m => MF.MonadFail (STT s m) where
   fail msg = lift (fail msg)
 
 instance MonadTrans (STT s) where

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -35,6 +35,9 @@ library
   else
     build-depends: base < 3
 
+  if impl(ghc < 8.0)
+    build-depends: fail
+
   exposed-modules:	
     Control.Monad.ST.Trans,
     Control.Monad.ST.Trans.Internal


### PR DESCRIPTION
GHC 8.8.1-alpha2 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2019-June/017777.html). In this PR I fixed the compilation with this version of GHC. All the changes were required by the MonadFail proposal (see [Library Changes](https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.8#base-41300) in GHC 8.8.1).

Blocking https://github.com/agda/agda/issues/3725.