### PR TITLE
Avoid defaults in MArray (STUArray s) instances, and add STUArray tests

### DIFF
--- a/Control/Monad/ST/Trans/Internal.hs
+++ b/Control/Monad/ST/Trans/Internal.hs
@@ -145,6 +145,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Bool (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -157,6 +161,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Char (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -169,6 +177,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Int (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -181,6 +193,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Word (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -193,6 +209,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) (Ptr a) (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -205,6 +225,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) (FunPtr a) (STT s m) wh
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -217,6 +241,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Float (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -229,6 +257,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Double (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -241,6 +273,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) (StablePtr a) (STT s m)
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -253,6 +289,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Int8 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -265,6 +305,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Int16 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -277,6 +321,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Int32 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -289,6 +337,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Int64 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -301,6 +353,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Word8 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -313,6 +369,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Word16 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -325,6 +385,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Word32 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}
@@ -337,6 +401,10 @@ instance (Applicative m, Monad m) => MArray (STUArray s) Word64 (STT s m) where
     getNumElements arr = liftST (getNumElements arr)
     {-# INLINE newArray #-}
     newArray bnds e = liftST (newArray bnds e)
+    {-# INLINE newArray_ #-}
+    newArray_ arrBounds = liftST (newArray_ arrBounds)
+    {-# INLINE unsafeNewArray_ #-}
+    unsafeNewArray_ bnds = liftST (unsafeNewArray_ bnds)
     {-# INLINE unsafeRead #-}
     unsafeRead arr i = liftST (unsafeRead arr i)
     {-# INLINE unsafeWrite #-}

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -61,3 +61,4 @@ test-suite test
                   , tasty-hunit >= 0.9.2 && < 0.11
                   , transformers >= 0.4 && < 0.6
                   , STMonadTrans
+                  , array

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,6 +7,7 @@ import GHC.Arr (Array, listArray, (//))
 import Control.Monad.ST.Trans
 import Control.Monad.Trans.Class
 import Control.Monad (guard)
+import Data.Array.ST (STUArray, freeze, newArray, newArray_, readArray, thaw, writeArray)
 
 props :: TestTree
 props = testGroup "Properties" [
@@ -20,26 +21,57 @@ props = testGroup "Properties" [
     \x y -> runSTT (do ref <- newSTRef x
                        writeSTRef ref y
                        readSTRef ref) == Just (y :: Int),
-  testProperty "newSTArray makes correct Arrays" $
-    \t e -> 0 <= t ==>
-      runSTT (newSTArray (0,t) e >>= freezeSTArray) ==
-      Just (listArray (0,t) (repeat e) :: Array Int Int),
-  testProperty "writeSTArray overwrite" $
-    \t e y -> 0 <= t ==>
-      runSTT (do arr <- newSTArray (0,t) e
-                 mapM_ (\i -> writeSTArray arr i y) [0..t]
-                 freezeSTArray arr) ==
-      Just (listArray (0,t) (repeat y) :: Array Int Int),
-  testProperty "thawSTArray . freezeSTArray == id" $
-    \l -> let a = listArray (0,length l - 1) l in
-      runSTT (thawSTArray a >>= freezeSTArray) == Just (a :: Array Int Int),
-  testProperty "writeSTArray . thawSTArray == update a" $
-    \l i e -> let a = listArray (0, length l - 1) l in
-      0 <= i && i < length l ==>
-        runSTT (do stArr <- thawSTArray a
-                   writeSTArray stArr i e
-                   freezeSTArray stArr) ==
-        Just (a // [(i,e)] :: Array Int Int) ]
+  testGroup "STArray" [
+    testProperty "newSTArray makes correct Arrays" $
+      \t e -> 0 <= t ==>
+        runSTT (newSTArray (0,t) e >>= freezeSTArray) ==
+        Just (listArray (0,t) (repeat e) :: Array Int Int),
+    testProperty "writeSTArray overwrite" $
+      \t e y -> 0 <= t ==>
+        runSTT (do arr <- newSTArray (0,t) e
+                   mapM_ (\i -> writeSTArray arr i y) [0..t]
+                   freezeSTArray arr) ==
+        Just (listArray (0,t) (repeat y) :: Array Int Int),
+    testProperty "thawSTArray . freezeSTArray == id" $
+      \l -> let a = listArray (0,length l - 1) l in
+        runSTT (thawSTArray a >>= freezeSTArray) == Just (a :: Array Int Int),
+    testProperty "writeSTArray . thawSTArray == update a" $
+      \l i e -> let a = listArray (0, length l - 1) l in
+        0 <= i && i < length l ==>
+          runSTT (do stArr <- thawSTArray a
+                     writeSTArray stArr i e
+                     freezeSTArray stArr) ==
+          Just (a // [(i,e)] :: Array Int Int) ],
+  testGroup "STUArray" [
+    testProperty "newArray makes correct Arrays" $
+      \t e -> 0 <= t ==>
+        runSTT (do stuArr <- newArray (0,t) e :: STT s Maybe (STUArray s Int Int)
+                   freeze stuArr) ==
+        Just (listArray (0,t) (repeat e) :: Array Int Int),
+    testProperty "writeArray overwrite" $
+      \t e y -> 0 <= t ==>
+        runSTT (do stuArr <- newArray (0,t) e :: STT s Maybe (STUArray s Int Int)
+                   mapM_ (\i -> writeArray stuArr i y) [0..t]
+                   freeze stuArr) ==
+        Just (listArray (0,t) (repeat y) :: Array Int Int),
+    testProperty "thaw . freeze == id" $
+      \l -> let a = listArray (0,length l - 1) l in
+        runSTT (do stuArr <- thaw a :: STT s Maybe (STUArray s Int Int)
+                   freeze stuArr) ==
+        Just (a :: Array Int Int),
+    testProperty "writeArray . thawArray == update a" $
+      \l i e -> let a = listArray (0, length l - 1) l in
+        0 <= i && i < length l ==>
+          runSTT (do stuArr <- thaw a :: STT s Maybe (STUArray s Int Int)
+                     writeArray stuArr i e
+                     freeze stuArr) ==
+          Just (a // [(i,e)] :: Array Int Int),
+    testProperty "writeArray overwrite uninitialised array" $
+      \t e -> 0 <= t ==>
+        runSTT (do stuArr <- newArray_ (0,t) :: STT s Maybe (STUArray s Int Int)
+                   mapM_ (\i -> writeArray stuArr i e) [0..t]
+                   freeze stuArr) ==
+        Just (listArray (0,t) (repeat e) :: Array Int Int) ] ]
 
 unitTests :: TestTree
 unitTests = testGroup "Unit Tests" [


### PR DESCRIPTION
Fixes #18.

Also adds some STUArray property tests.
Three of them fail pre-PR:
```
STUArray
  thaw . freeze == id:                      FAIL
    *** Failed! (after 3 tests and 1 shrink):
    Exception:
      MArray: undefined array element
      CallStack (from HasCallStack):
        error, called at libraries/array/Data/Array/Base.hs:793:16 in array-0.5.3.0:Data.Array.Base
    [0]
    Use --quickcheck-replay=494660 to reproduce.
  writeArray . thawArray == update a:       FAIL
    *** Failed! (after 1 test and 3 shrinks):
    Exception:
      MArray: undefined array element
      CallStack (from HasCallStack):
        error, called at libraries/array/Data/Array/Base.hs:793:16 in array-0.5.3.0:Data.Array.Base
    [0]
    0
    0
    Use --quickcheck-replay=947387 to reproduce.
  writeArray overwrite uninitialised array: FAIL
    *** Failed! (after 1 test):
    Exception:
      MArray: undefined array element
      CallStack (from HasCallStack):
        error, called at libraries/array/Data/Array/Base.hs:793:16 in array-0.5.3.0:Data.Array.Base
    0
    0
    Use --quickcheck-replay=576570 to reproduce.
```
