### PR TITLE
Weaken the constraint on transformers

### DIFF
--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -34,7 +34,7 @@ library
   build-depends: base >= 4.6
         
   if flag(splitBase)
-    build-depends: base >= 3, base < 5, mtl, array
+    build-depends: base >= 3, base < 5, mtl >= 1.1 , array
   else
     build-depends: base < 3
 
@@ -59,6 +59,6 @@ test-suite test
                   , tasty >= 0.11.0.4 && < 1.5
                   , tasty-quickcheck >= 0.8.4 && < 0.11
                   , tasty-hunit >= 0.9.2 && < 0.11
-                  , transformers >= 0.4 && < 0.6
+                  , transformers >= 0.2 && < 0.6
                   , STMonadTrans
                   , array


### PR DESCRIPTION
We currently cannot build on ghc 7.8.4 because we have too restrictive
constraints on transformers. Since we use very little of that package
we can weaken the constraints considerably.

This diff also corrects the constraint on mtl. We need at least
version 1.1. This particular constraint should be very easy to satify.