### PR TITLE
Drop flag `splitBase`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20201221
+# version: 0.13.20210606
 #
-# REGENDATA ("0.11.20201221",["github","STMonadTrans.cabal"])
+# REGENDATA ("0.13.20210606",["github","STMonadTrans.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,7 +18,7 @@ on:
   - pull_request
 jobs:
   linux:
-    name: Haskell-CI Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
@@ -26,54 +26,92 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 8.10.3
+          - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-8.10.4
+            compilerKind: ghc
+            compilerVersion: 8.10.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.2.2
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.0.2
+          - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.10.3
+          - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.8.4
+          - compiler: ghc-7.10.3
+            compilerKind: ghc
+            compilerVersion: 7.10.3
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.6.3
+          - compiler: ghc-7.8.4
+            compilerKind: ghc
+            compilerVersion: 7.8.4
+            setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-7.6.3
+            compilerKind: ghc
+            compilerVersion: 7.6.3
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2
+          apt-get install -y "$HCNAME" cabal-install-3.4
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.2/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          HC=$HCDIR/bin/$HCKIND
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -82,7 +120,7 @@ jobs:
           mkdir -p $CABAL_DIR
           cat >> $CABAL_CONFIG <<EOF
           remote-build-reporting: anonymous
-          write-ghc-environment-files: always
+          write-ghc-environment-files: never
           remote-repo-cache: $CABAL_DIR/packages
           logs-dir:          $CABAL_DIR/logs
           world-file:        $CABAL_DIR/world
@@ -113,14 +151,19 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+          cabal-plan --version
       - name: checkout
         uses: actions/checkout@v2
         with:
           path: source
+      - name: initial cabal.project for sdist
+        run: |
+          touch cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
+          cat cabal.project
       - name: sdist
         run: |
           mkdir -p sdist
-          cd source || false
           $CABAL sdist all --output-dir $GITHUB_WORKSPACE/sdist
       - name: unpack
         run: |
@@ -129,7 +172,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_STMonadTrans="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/STMonadTrans-[0-9.]*')"
-          echo "PKGDIR_STMonadTrans=${PKGDIR_STMonadTrans}" >> $GITHUB_ENV
+          echo "PKGDIR_STMonadTrans=${PKGDIR_STMonadTrans}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_STMonadTrans}" >> cabal.project
@@ -147,9 +191,9 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
@@ -159,7 +203,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: build
         run: |
-          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # STMonadTrans
 
+[![Build Status](https://github.com/josefs/STMonadTrans/workflows/Haskell-CI/badge.svg)](https://github.com/josefs/STMonadTrans/actions)
+<!--
 [![Build Status](https://travis-ci.org/josefs/STMonadTrans.svg?branch=master)](https://travis-ci.org/josefs/STMonadTrans)
-[![Hackage](https://img.shields.io/hackage/v/STMonadTrans.svg)](https://hackage.haskell.org/package/STMonadTrans)
+-->
+[![Hackage](https://img.shields.io/hackage/v/STMonadTrans.svg?label=Hackage&color=informational)](https://hackage.haskell.org/package/STMonadTrans)
 [![STMonadTrans on Stackage Nightly](https://stackage.org/package/STMonadTrans/badge/nightly)](https://stackage.org/nightly/package/STMonadTrans)
 [![Stackage](https://www.stackage.org/package/STMonadTrans/badge/lts?label=Stackage)](https://www.stackage.org/package/STMonadTrans)
 

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -26,7 +26,8 @@ Tested-With: GHC == 7.6.3
            , GHC == 8.4.4
            , GHC == 8.6.5
            , GHC == 8.8.4
-           , GHC == 8.10.3
+           , GHC == 8.10.4
+           , GHC == 9.0.1
 
 extra-source-files:
         changelog.md
@@ -35,27 +36,28 @@ source-repository head
   type:     git
   location: https://github.com/josefs/STMonadTrans
 
-flag splitBase
-  description: Choose the new smaller, split-up base package.
-
 library
   default-language: Haskell2010
-  build-depends: base >= 4.6
+  build-depends:    base    >= 4.6 && < 5
+                  , mtl     >= 1.1
+                  , array
 
-  if flag(splitBase)
-    build-depends: base >= 3, base < 5, mtl >= 1.1, array
-  else
-    build-depends: base < 3
-
+  -- MonadFail for GHC <= 7
   if impl(ghc < 8.0)
-    build-depends: fail
+    build-depends:  fail
 
   exposed-modules:
-    Control.Monad.ST.Trans,
+    Control.Monad.ST.Trans
     Control.Monad.ST.Trans.Internal
-  default-extensions: CPP, MagicHash, UnboxedTuples, Rank2Types,
-                FlexibleInstances,
-                MultiParamTypeClasses, UndecidableInstances
+
+  default-extensions:
+    CPP
+    MagicHash
+    UnboxedTuples
+    Rank2Types
+    FlexibleInstances
+    MultiParamTypeClasses
+    UndecidableInstances
 
   ghc-options: -Wall -fwarn-tabs
 

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -30,7 +30,8 @@ Tested-With: GHC == 7.6.3
            , GHC == 9.0.1
 
 extra-source-files:
-        changelog.md
+  README.md
+  changelog.md
 
 source-repository head
   type:     git


### PR DESCRIPTION
* Test GHC 8.10.5 and 9.0.1, drop splitBase flag.
    
* Flag splitBase supported compilation with base < 3, but we anyway do not support GHC < 7.6.

* README: Get build status from GitHub, ship README with tarball.

