### PR TITLE
Release 0.4.6

### DIFF
--- a/Control/Monad/ST/Trans.hs
+++ b/Control/Monad/ST/Trans.hs
@@ -5,8 +5,8 @@
                   (c) The University of Glasgow, 1994-2000
    License     :  BSD
 
-   Maintainer  :  josef.svenningsson@gmail.com
-   Stability   :  experimental
+   Maintainer  :  josef.svenningsson@gmail.com, Andreas Abel
+   Stability   :  stable
    Portability :  non-portable (GHC Extensions)
 
    This library provides a monad transformer version of the ST monad.
@@ -15,8 +15,8 @@
    can contain multiple answers, like the list monad. The reason is that
    the state token will be duplicated across the different answers and
    this causes Bad Things to happen (such as loss of referential
-   transparency). Safe monads include the monads State, Reader, Writer,
-   Maybe and combinations of their corresponding monad transformers.
+   transparency). Safe monads include the monads @'State'@, @'Reader'@, @'Writer'@,
+   @'Maybe'@ and combinations of their corresponding monad transformers.
 
 -}
 module Control.Monad.ST.Trans(

--- a/Control/Monad/ST/Trans.hs
+++ b/Control/Monad/ST/Trans.hs
@@ -49,28 +49,25 @@ module Control.Monad.ST.Trans(
       unsafeSTTToIO,
       unsafeSTRefToIORef,
       unsafeIORefToSTRef
-      )where
+      ) where
 
-import GHC.Base
-import GHC.Arr (Array(..))
+import GHC.Base            (realWorld#)
+import GHC.Arr             (Ix, Array(..))
 import qualified GHC.Arr as STArray
 
-import Data.STRef (STRef)
-import qualified Data.STRef as STRef
-
-import Data.Array.ST hiding (runSTArray)
---import qualified Data.Array.ST as STArray
-
 #if __GLASGOW_HASKELL__ <= 708
-import Control.Applicative
+import Control.Applicative (Applicative)
 #endif
 
 import Control.Monad.ST.Trans.Internal
 
-import Data.IORef
+import Data.Array.ST       (STArray, newArray, readArray, writeArray)
+import Data.IORef          (IORef)
+import Data.STRef          (STRef)
+import qualified Data.STRef as STRef
 
-import Unsafe.Coerce
-import System.IO.Unsafe
+import System.IO.Unsafe    (unsafePerformIO)
+import Unsafe.Coerce       (unsafeCoerce)
 
 {-# INLINE newSTRef #-}
 -- | Create a new reference

--- a/Control/Monad/ST/Trans/Internal.hs
+++ b/Control/Monad/ST/Trans/Internal.hs
@@ -6,8 +6,8 @@
                   (c) The University of Glasgow, 1994-2000
    License     :  BSD
 
-   Maintainer  :  josef.svenningsson@gmail.com
-   Stability   :  experimental
+   Maintainer  :  josef.svenningsson@gmail.com, Andreas Abel
+   Stability   :  stable
    Portability :  non-portable (GHC Extensions)
 
    This module provides the implementation of the 'STT' type for those

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 # STMonadTrans
 
-[![Build Status](https://github.com/josefs/STMonadTrans/workflows/Haskell-CI/badge.svg)](https://github.com/josefs/STMonadTrans/actions)
-<!--
-[![Build Status](https://travis-ci.org/josefs/STMonadTrans.svg?branch=master)](https://travis-ci.org/josefs/STMonadTrans)
--->
 [![Hackage](https://img.shields.io/hackage/v/STMonadTrans.svg?label=Hackage&color=informational)](https://hackage.haskell.org/package/STMonadTrans)
 [![STMonadTrans on Stackage Nightly](https://stackage.org/package/STMonadTrans/badge/nightly)](https://stackage.org/nightly/package/STMonadTrans)
 [![Stackage](https://www.stackage.org/package/STMonadTrans/badge/lts?label=Stackage)](https://www.stackage.org/package/STMonadTrans)
+[![Build Status](https://github.com/josefs/STMonadTrans/workflows/Haskell-CI/badge.svg)](https://github.com/josefs/STMonadTrans/actions)
 
-A monad transformer version of the [ST monad](https://hackage.haskell.org/package/base/docs/Control-Monad-ST.html)
+A monad transformer version of the [ST monad](https://hackage.haskell.org/package/base/docs/Control-Monad-ST.html).
 
 Warning! This monad transformer should not be used with monads that
 can contain multiple answers, like the list monad. The reason is that
 the state token will be duplicated across the different answers and
 this causes Bad Things to happen (such as loss of referential
-transparency). Safe monads include the monads State, Reader, Writer,
-Maybe and combinations of their corresponding monad transformers.
+transparency). Safe monads include the monads `State`, `Reader`, `Writer`,
+`Maybe` and combinations of their corresponding monad transformers.

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -11,8 +11,8 @@ category:	Monads
 build-type:	Simple
 synopsis:	A monad transformer version of the ST monad
 description:
-   A monad transformer version of the ST monad
-
+   A monad transformer version of the ST monad.
+   .
    Warning! This monad transformer should not be used with monads that
    can contain multiple answers, like the list monad. The reason is that
    the state token will be duplicated across the different answers and

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,14 @@
+0.4.6
+
+  * Warning-free for all supported GHC versions (7.6 -- 9.2).
+  * Drop `splitBase` cabal flag (`base >= 4` is already assumed).
+  * Include `README.md` in distributed tarball.
+  * Added maintainer Andreas Abel.
+
 0.4.5
 
-  * Don't use default class methods in any MArray (STUArray s) instance. Thanks to Henri Jones
-  * Allow tasty up to and including 1.4
+  * Don't use default class methods in any `MArray (STUArray s)` instance. Thanks to Henri Jones.
+  * Allow `tasty` up to and including 1.4.
 
 0.4.4
 
@@ -11,21 +18,21 @@
 0.4.3
 
   * Fix compilation for GHC 7.6.3. Thanks to Andrés Sicard-Ramírez.
-  * Export unsafe array operations
+  * Export unsafe array operations.
 
 0.4.2
 
-  * Deprecate runST and unsafeSTToIO in favor of
-    runSTT and unsafeSTTToIO.
-  * Added INLINE pragmas
+  * Deprecate `runST` and `unsafeSTToIO` in favor of
+    `runSTT` and `unsafeSTTToIO`.
+  * Added `INLINE` pragmas.
 
 0.4.1
 
-  * Add Applicative constraints to be compatible with GHC 7.8.4
-  * Add changelog
+  * Add `Applicative` constraints to be compatible with GHC 7.8.4.
+  * Add changelog.
 
 0.4
 
-  * New library structure, based on liftST. It reuses more code and
-    types from the standard ST monad. Thanks to @wyager for liftST.
-  * Instances for MArray
+  * New library structure, based on `liftST`. It reuses more code and
+    types from the standard `ST` monad. Thanks to @wyager for `liftST`.
+  * Instances for `MArray`.


### PR DESCRIPTION
Changelog and cosmetic changes.

Release candidate is up at: https://hackage.haskell.org/package/STMonadTrans-0.4.6/candidate