### PR TITLE
Remove MonadFail instance

### DIFF
--- a/Control/Monad/ST/Trans/Internal.hs
+++ b/Control/Monad/ST/Trans/Internal.hs
@@ -73,9 +73,6 @@ instance (Monad m, Functor m) => Monad (STT s m) where
          STTRet new_st a ->
              unSTT (k a) new_st
 
-instance (MF.MonadFail m, Functor m) => MF.MonadFail (STT s m) where
-  fail msg = lift (fail msg)
-
 instance MonadTrans (STT s) where
   lift m = STT $ \st ->
    do a <- m


### PR DESCRIPTION
The `ST` monad is losing its `MonadFail` instance. See  haskell/core-libraries-committee#33
I suggest we do the same.