### PR TITLE
release 0.4.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20231012
+# version: 0.17.20231112
 #
-# REGENDATA ("0.17.20231012",["github","STMonadTrans.cabal"])
+# REGENDATA ("0.17.20231112",["github","STMonadTrans.cabal"])
 #
 name: Haskell-CI
 on:
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -87,34 +87,17 @@ jobs:
             compilerVersion: 8.0.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          fi
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -126,22 +109,13 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - master
-      - ci*
   pull_request:
     branches:
       - master
-      - ci*
 
 defaults:
   run:
@@ -24,13 +22,13 @@ jobs:
         include:
         - os: ubuntu-latest
           ghc: 9.8.1
-          resolver: nightly-2023-10-17
+          resolver: nightly-2024-01-04
         - os: ubuntu-latest
           ghc: 9.6.3
-          resolver: nightly-2023-10-17
+          resolver: lts-22.4
         - os: ubuntu-latest
-          ghc: 9.4.7
-          resolver: lts-21.16
+          ghc: 9.4.8
+          resolver: lts-21.25
         - os: ubuntu-latest
           ghc: 9.2.8
           resolver: lts-20.26

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -24,7 +24,7 @@ description:
 Tested-With:
   GHC == 9.8.1
   GHC == 9.6.3
-  GHC == 9.4.7
+  GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -33,7 +33,6 @@ Tested-With:
   GHC == 8.4.4
   GHC == 8.2.2
   GHC == 8.0.2
-  GHC == 7.10.3
 
 extra-doc-files:
   README.md
@@ -46,14 +45,10 @@ source-repository head
 library
   default-language: Haskell2010
   build-depends:
-      base         >= 4.6      && < 5
+      base         >= 4.9      && < 5
     , transformers >= 0.2.0.0  && < 0.7
     , mtl          >= 1.1
     , array
-
-  -- MonadFail for GHC <= 7
-  if impl(ghc < 8.0)
-    build-depends:  fail
 
   exposed-modules:
     Control.Monad.ST.Trans
@@ -72,10 +67,7 @@ library
   ghc-options:
     -Wall
     -fwarn-tabs
-
-  if impl(ghc >= 8.0)
-    ghc-options:
-      -Wcompat
+    -Wcompat
 
 test-suite test
   default-language: Haskell2010

--- a/STMonadTrans.cabal
+++ b/STMonadTrans.cabal
@@ -1,16 +1,15 @@
 cabal-version:  1.18
-name:		STMonadTrans
-version:	0.4.7
-x-revision:     1
-license:	BSD3
-license-file:	LICENSE
-author:		Josef Svenningsson
-maintainer:	josef.svenningsson@gmail.com, Andreas Abel
+name:           STMonadTrans
+version:        0.4.8
+license:        BSD3
+license-file:   LICENSE
+author:         Josef Svenningsson
+maintainer:     Andreas Abel, josef.svenningsson@gmail.com
 homepage:       https://github.com/josefs/STMonadTrans
 bug-reports:    https://github.com/josefs/STMonadTrans/issues
-category:	Monads
-build-type:	Simple
-synopsis:	A monad transformer version of the ST monad
+category:       Monads
+build-type:     Simple
+synopsis:       A monad transformer version of the ST monad
 description:
    A monad transformer version of the ST monad.
    .

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,18 @@
-0.4.7
+0.4.8 -- 2023-01-04
+
+  * Added `Alternative` instance for `STT`, by William Rusnack
+    (PR [#33](https://github.com/josefs/STMonadTrans/pull/33)).
+  * Drop support for GHC 7.
+  * Tested with GHC 8.0.2 - 9.8.1.
+
+0.4.7 -- 2023-05-18
 
   * Added `MonadIO` for `SST` (issue [#29](https://github.com/josefs/STMonadTrans/issues/29)).
   * Make `transformers` dependency explicit.
   * Bump `cabal-version` of `STMonadTrans.cabal` to 1.18.
   * Tested with GHC 7.6.3 - 9.6.1.
 
-0.4.6
+0.4.6 -- 2021-08-21
 
   * Warning-free for all supported GHC versions (7.6 -- 9.2).
   * Drop `splitBase` cabal flag (`base >= 4` is already assumed).


### PR DESCRIPTION
- Drop support for GHC 7
- Bump to 0.4.8 and changelog entry

Release candidate at: https://hackage.haskell.org/package/STMonadTrans-0.4.8/candidate